### PR TITLE
Added command for copying as comma-separated array of strings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,6 +31,32 @@ exports.activate = context => {
     });
 
     context.subscriptions.push(copyFilename);
+
+    //Register command
+    const copyFilenameAsStringArray = vscode.commands.registerCommand('extension.copyFileNameStringArrayFormat', (uri, files) => {
+        let accumulator = '';
+
+        if(typeof files !== 'undefined' && files.length > 0) {
+            files.forEach((el, index) => {
+                //get the relative url, parse it and take the last part
+                let url = vscode.workspace.asRelativePath(el.path);
+                let urlFormatted = url.replace(/\\/g, '/')
+                accumulator += '\"';
+                accumulator += urlFormatted.split('/').pop().replace(/\.[^\.]+$/, "");
+                accumulator += '\"';
+                accumulator += (index == files.length -1) ? '' : ',\n';
+            });
+        } else if(uri) {
+            let url = vscode.workspace.asRelativePath(uri);
+            let urlFormatted = url.replace(/\\/g, '/')
+            accumulator += urlFormatted.split('/').pop();
+        }
+
+        //Copy the last part to clipboard
+        clipboardy.write(accumulator).then(showWarning('Filename/s has been copied to clipboard'));
+    });
+
+    context.subscriptions.push(copyFilenameAsStringArray);
 }
 
 exports.deactivate = () => { };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "copy-filename",
     "displayName": "Copy filename",
-    "description": "Simple VS Code plugin that allows you to copy file name or folder name to clipboard from sidebar or opened file label",
+    "description": "Simple VS Code plugin that allows you to copy file names or folder names to clipboard from sidebar or opened file label as a comma-separated array of strings",
     "license": "MIT",
     "version": "2.3.2",
     "publisher": "jack89ita",
@@ -19,7 +19,8 @@
         "folder"
     ],
     "activationEvents": [
-        "onCommand:extension.copyFileName"
+        "onCommand:extension.copyFileName",
+        "onCommand:extension.copyFileNameStringArrayFormat"
     ],
     "main": "./extension",
     "contributes": {
@@ -27,17 +28,27 @@
             {
                 "command": "extension.copyFileName",
                 "title": "Copy name to clipboard"
+            },
+            {
+                "command": "extension.copyFileNameStringArrayFormat",
+                "title": "Copy file name(s) to clipboard as array of strings"
             }
         ],
         "menus": {
             "explorer/context": [
                 {
                     "command": "extension.copyFileName"
+                },
+                {
+                    "command": "extension.copyFileNameStringArrayFormat"
                 }
             ],
             "editor/title/context": [
                 {
                     "command": "extension.copyFileName"
+                },
+                {
+                    "command": "extension.copyFileNameStringArrayFormat"
                 }
             ]
         }


### PR DESCRIPTION
Original just copies a list of file names. One would typically use this again in code/script to re-use. Hence, hereby another button to copy instead as a comma-separated list of strings, to allow for immediate use as array input in code or Json.